### PR TITLE
fix: update github template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,6 @@
 
 <!--
-  If reporting a bug, please create a replication using this starter:
-  https://stackblitz.com/edit/terminus-ngx-tools-starter
+  If reporting a bug, please create a replication by forking this starter:
+  https://stackblitz.com/github/GetTerminus/ngx-tools
 -->
 


### PR DESCRIPTION
Trigger build since last commit didn't use 'fix'


<!--
  If reporting a bug, please create a replication using this starter:
  https://stackblitz.com/edit/terminus-ngx-tools-starter
-->

