### PR TITLE
fix(Utility): allow passed in formControl to be null

### DIFF
--- a/ngx-tools/src/update-control-on-input-changes/update-control-on-input-changes.spec.ts
+++ b/ngx-tools/src/update-control-on-input-changes/update-control-on-input-changes.spec.ts
@@ -18,6 +18,9 @@ describe(`updateControlOnInputChanges`, () => {
     expect(updateControlOnInputChanges(null, 'foo', control)).toEqual(false);
   });
 
+  test(`should return false if control is null`, () => {
+    expect(updateControlOnInputChanges(changed, 'item1', null)).toEqual(false);
+  })
 
   test(`should return true if the value has changed`, () => {
     expect(updateControlOnInputChanges(changed, 'item1', control)).toEqual(true);

--- a/ngx-tools/src/update-control-on-input-changes/update-control-on-input-changes.ts
+++ b/ngx-tools/src/update-control-on-input-changes/update-control-on-input-changes.ts
@@ -15,7 +15,7 @@ import { inputHasChanged } from './../input-has-changed/input-has-changed';
 export function updateControlOnInputChanges(
   changes: SimpleChanges,
   key: string,
-  control: AbstractControl,
+  control: AbstractControl | null,
 ): boolean {
   if (!changes || !key || !control) {
     return false;


### PR DESCRIPTION
Allow updateControlOnInputChanges take formControl being null.

