### PR TITLE
docs(Testing): now correctly showing the type being passed in

### DIFF
--- a/ngx-tools/testing/README.md
+++ b/ngx-tools/testing/README.md
@@ -545,7 +545,7 @@ export class TestComponent {
 }
 
 test(`should do something`, () => {
-  const fixture = createComponent(TestComponent);
+  const fixture = createComponent<TestComponent>(TestComponent);
 
   expect(fixture.componentInstance.foo).toEqual('bar');
 });


### PR DESCRIPTION
When the type isn't passed in, TypeScript doesn't offer any guidance.