### PR TITLE
fix(Testing): createKeyboardEvent initialization works with HostListener

### DIFF
--- a/ngx-tools/testing/src/utilities/event-objects.ts
+++ b/ngx-tools/testing/src/utilities/event-objects.ts
@@ -93,10 +93,8 @@ export function createKeyboardEvent(
   // NOTE: Cannot 'type' the event here due to the note about FireFox below
   const event = document.createEvent('KeyboardEvent') as any;
   // Firefox does not support `initKeyboardEvent`, but supports `initKeyEvent`.
-  const initEventFn = (event.initKeyEvent || event.initKeyboardEvent).bind(event);
+  (event.initKeyEvent || event.initKeyboardEvent).bind(event);
   const originalPreventDefault = event.preventDefault;
-
-  initEventFn(type, true, true, window, 0, 0, 0, 0, 0, keyCode);
 
   // Webkit Browsers don't set the keyCode when calling the init function.
   // See related bug https://bugs.webkit.org/show_bug.cgi?id=16735


### PR DESCRIPTION
ISSUES CLOSED: #208

This worked locally, but will have to test again in terminus-ui after this is committed. For that reason, I did not attach the ticket. If this works, I will close 208, if this doesn't work, I will try again.