### PR TITLE
fix(Keycodes): remove deprecated event initializer and use initEvent

### DIFF
--- a/ngx-tools/testing/src/utilities/event-objects.ts
+++ b/ngx-tools/testing/src/utilities/event-objects.ts
@@ -91,8 +91,7 @@ export function createKeyboardEvent(
 ): KeyboardEvent {
   // NOTE: Cannot 'type' the event here due to the note about FireFox below
   const event = document.createEvent('KeyboardEvent') as any;
-  // Firefox does not support `initKeyboardEvent`, but supports `initKeyEvent`.
-  (event.initKeyEvent || event.initKeyboardEvent).bind(event);
+  event.initEvent(type, true, false);
   const originalPreventDefault = event.preventDefault;
 
   // Webkit Browsers don't set the keyCode when calling the init function.


### PR DESCRIPTION
remove deprecated keyboard init event and use correct `initEvent` instead.