### PR TITLE
fix(Utility): fixes issue with AOT build failing to store initial token

### DIFF
--- a/ngx-tools/src/jwt-token-managment/module.ts
+++ b/ngx-tools/src/jwt-token-managment/module.ts
@@ -46,15 +46,13 @@ export const reducers: ActionReducerMap<State, any> = {
   ],
 })
 export class JwtTokenManagementModule {
-  static forRoot<CM>({
-    initialTokenName,
-  }: {initialTokenName: keyof CM}) {
+  static forRoot<CM>(options: {initialTokenName: keyof CM}) {
     return {
       ngModule: JwtTokenManagementModule,
       providers: [
         {
           provide: INITIAL_TOKEN_NAME,
-          useValue: initialTokenName,
+          useValue: options.initialTokenName,
         },
       ],
     };


### PR DESCRIPTION
I have no idea why this fixes it


<!--
  If reporting a bug, please create a replication by forking this starter:
  https://stackblitz.com/github/GetTerminus/ngx-tools
-->

