### PR TITLE
292 add type guards from ui lib

### DIFF
--- a/ngx-tools/type-guards/README.md
+++ b/ngx-tools/type-guards/README.md
@@ -14,6 +14,7 @@ A collection of consistent, tested, and well-performing checks for various types
 - [`isArrayOfType`](#isarrayoftype)
 - [`isArray`](#isarray)
 - [`isBoolean`](#isboolean)
+- [`isDragEvent`](#isdragevent)
 - [`isFunction`](#isfunction)
 - [`isHttpResponse`](#ishttpresponse)
 - [`isNull`](#isnull)
@@ -97,6 +98,20 @@ import { isBoolean } from '@terminus/ngx-tools/type-guards';
 
 isBoolean(true);   // Returns: true
 isBoolean('true'); // Returns: false
+```
+
+
+## `isDragEvent`
+
+[[source]](src/is-drag-event/is-drag-event.ts)
+
+Determine if an event is a `DragEvent`.
+
+```typescript
+import { isDragEvent } from '@terminus/ngx-tools/type-guards';
+
+isDragEvent(myDragEvent);  // Returns: true
+isDragEvent(myClickEvent); // Returns: false
 ```
 
 

--- a/ngx-tools/type-guards/README.md
+++ b/ngx-tools/type-guards/README.md
@@ -16,6 +16,7 @@ A collection of consistent, tested, and well-performing checks for various types
 - [`isBoolean`](#isboolean)
 - [`isDragEvent`](#isdragevent)
 - [`isFunction`](#isfunction)
+- [`isHTMLInputElement`](#ishtmlinputelement)
 - [`isHttpResponse`](#ishttpresponse)
 - [`isNull`](#isnull)
 - [`isNumber`](#isnumber)
@@ -126,6 +127,23 @@ import { isFunction } from '@terminus/ngx-tools/type-guards';
 
 isFunction(() => {}); // Returns: true
 isFunction('foo');    // Returns: false
+```
+
+
+## `isHTMLInputElement`
+
+[[source]](src/is-html-input-element/is-html-input-element.ts)
+
+Determine if a value is an HTML input element.
+
+```typescript
+import { isHTMLInputElement } from '@terminus/ngx-tools/type-guards';
+
+const myInput = document.querySelector('#myInput');
+const myDiv = document.querySelector('#myDiv');
+
+isHTMLInputElement(myInput); // Returns: true
+isHTMLInputElement(myDiv);   // Returns: false
 ```
 
 

--- a/ngx-tools/type-guards/README.md
+++ b/ngx-tools/type-guards/README.md
@@ -18,6 +18,7 @@ A collection of consistent, tested, and well-performing checks for various types
 - [`isFunction`](#isfunction)
 - [`isHTMLInputElement`](#ishtmlinputelement)
 - [`isHttpResponse`](#ishttpresponse)
+- [`isKeyboardEvent`](#iskeyboardevent)
 - [`isNull`](#isnull)
 - [`isNumber`](#isnumber)
 - [`isObject`](#isobject)
@@ -158,6 +159,20 @@ import { isHttpResponse } from '@terminus/ngx-tools/type-guards';
 
 isHttpResponse({headers: {...}});             // Returns: true
 isHttpResponse<MyResponseType>({foo: 'bar'}); // Returns: false
+```
+
+
+## `isKeyboardEvent`
+
+[[source]](src/is-keyboard-event/is-keyboard-event.ts)
+
+Determine if an event is a `KeyboardEvent`.
+
+```typescript
+import { isKeyboardEvent } from '@terminus/ngx-tools/type-guards';
+
+isKeyboardEvent(myKeyboardEvent); // Returns: true
+isKeyboardEvent(myClickEvent);    // Returns: false
 ```
 
 

--- a/ngx-tools/type-guards/README.md
+++ b/ngx-tools/type-guards/README.md
@@ -19,6 +19,7 @@ A collection of consistent, tested, and well-performing checks for various types
 - [`isHTMLInputElement`](#ishtmlinputelement)
 - [`isHttpResponse`](#ishttpresponse)
 - [`isKeyboardEvent`](#iskeyboardevent)
+- [`isMouseEvent`](#ismouseevent)
 - [`isNull`](#isnull)
 - [`isNumber`](#isnumber)
 - [`isObject`](#isobject)
@@ -173,6 +174,20 @@ import { isKeyboardEvent } from '@terminus/ngx-tools/type-guards';
 
 isKeyboardEvent(myKeyboardEvent); // Returns: true
 isKeyboardEvent(myClickEvent);    // Returns: false
+```
+
+
+## `isMouseEvent`
+
+[[source]](src/is-mouse-event/is-mouse-event.ts)
+
+Determine if an event is a `MouseEvent`.
+
+```typescript
+import { isMouseEvent } from '@terminus/ngx-tools/type-guards';
+
+isMouseEvent(myMouseEvent); // Returns: true
+isMouseEvent(myClickEvent); // Returns: false
 ```
 
 

--- a/ngx-tools/type-guards/src/is-array-of-type/is-array-of-type.ts
+++ b/ngx-tools/type-guards/src/is-array-of-type/is-array-of-type.ts
@@ -6,8 +6,8 @@
  * @return The result
  *
  * @example
- * isArrayOfType<number>([1, 5], isNumber) // Returns true
- * isArrayOfType<number>([1, 'foo'], isNumber) // Returns false
+ * isArrayOfType<number>([1, 5], isNumber)     // Returns: true
+ * isArrayOfType<number>([1, 'foo'], isNumber) // Returns: false
  */
 // tslint:disable-next-line no-any
 export function isArrayOfType<T>(x: any[], guard: (y: any) => y is T): x is T[] {

--- a/ngx-tools/type-guards/src/is-drag-event/is-drag-event.spec.ts
+++ b/ngx-tools/type-guards/src/is-drag-event/is-drag-event.spec.ts
@@ -1,0 +1,47 @@
+import { createMouseEvent } from '@terminus/ngx-tools/testing';
+
+import { isDragEvent } from './is-drag-event';
+
+
+describe(`isDragEvent`, function() {
+  const DataTransferMock = function() {
+    this.dataByFormat = {};
+    this.dropEffect = 'none';
+    this.effectAllowed = 'all';
+    this.files = [];
+    this.types = [];
+  };
+  const dragEvent = createMouseEvent('click') as DragEvent;
+  Object.defineProperties(dragEvent, {dataTransfer: {get: () => DataTransferMock}});
+  const mouseEvent = createMouseEvent('click');
+
+  const validEvents: any[] = [
+    {dataTransfer: {}},
+    dragEvent,
+  ];
+
+  const invalidEvents: any[] = [
+    null,
+    undefined,
+    'foo',
+    [],
+    {},
+    () => true,
+    mouseEvent,
+  ];
+
+
+  test(`should return true for a drag event value`, () => {
+    for (const test of validEvents) {
+      expect(isDragEvent(test)).toEqual(true);
+    }
+  });
+
+
+  test(`should return false for a non-drag event value`, () => {
+    for (const test of invalidEvents) {
+      expect(isDragEvent(test)).toEqual(false);
+    }
+  });
+
+});

--- a/ngx-tools/type-guards/src/is-drag-event/is-drag-event.ts
+++ b/ngx-tools/type-guards/src/is-drag-event/is-drag-event.ts
@@ -1,0 +1,17 @@
+import { isSet } from './../is-set/is-set';
+
+
+/**
+ * Coerce the type to DragEvent
+ *
+ * @param x - The item to test
+ * @return True if the value is a DragEvent
+ *
+ * @example
+ * isDragEvent(myDragEvent);  // Returns: true
+ * isDragEvent(myClickEvent); // Returns: false
+ */
+// tslint:disable-next-line no-any
+export function isDragEvent(x: any): x is DragEvent {
+  return !!x && isSet(x.dataTransfer);
+}

--- a/ngx-tools/type-guards/src/is-html-input-element/is-html-input-element.spec.ts
+++ b/ngx-tools/type-guards/src/is-html-input-element/is-html-input-element.spec.ts
@@ -1,0 +1,36 @@
+import { isHTMLInputElement } from './is-html-input-element';
+
+
+describe(`isHTMLInputElement`, function() {
+
+  const validElements = [
+    document.createElement('input'),
+  ];
+
+  const invalidElements = [
+    null,
+    void 0,
+    'hi',
+    0,
+    [],
+    {},
+    document.createElement('button'),
+    document.createElement('a'),
+    document.createElement('div'),
+  ];
+
+
+  test(`should return true for all valid elements`, function() {
+    for (const test of validElements) {
+      expect(isHTMLInputElement(test)).toEqual(true);
+    }
+  });
+
+
+  test(`should return false for all invalid elements`, function() {
+    for (const test of invalidElements) {
+      expect(isHTMLInputElement(test)).toEqual(false);
+    }
+  });
+
+});

--- a/ngx-tools/type-guards/src/is-html-input-element/is-html-input-element.ts
+++ b/ngx-tools/type-guards/src/is-html-input-element/is-html-input-element.ts
@@ -1,0 +1,20 @@
+import { isSet } from './../is-set/is-set';
+
+
+/**
+ * Coerce the type to HTMLInputElement
+ *
+ * @param x - The item to test
+ * @return True if the value is a HTMLInputElement
+ *
+ * @example
+ * const myInput = document.querySelector('#myInput');
+ * const myDiv = document.querySelector('#myDiv');
+ *
+ * isHTMLInputElement(myInput); // Returns: true
+ * isHTMLInputElement(myDiv);   // Returns: false
+ */
+// tslint:disable-next-line no-any
+export function isHTMLInputElement(x: any): x is HTMLInputElement {
+  return !!x && isSet(x.files);
+}

--- a/ngx-tools/type-guards/src/is-keyboard-event/is-keyboard-event.spec.ts
+++ b/ngx-tools/type-guards/src/is-keyboard-event/is-keyboard-event.spec.ts
@@ -1,0 +1,23 @@
+import { KEYS } from '@terminus/ngx-tools/keycodes';
+import {
+  createKeyboardEvent,
+  createMouseEvent,
+} from '@terminus/ngx-tools/testing';
+
+import { isKeyboardEvent } from './is-keyboard-event';
+
+
+describe(`isKeyboardEvent`, function() {
+
+  test(`should return true for a keyboard event`, function() {
+    const event = createKeyboardEvent('keyup', KEYS.ENTER);
+    expect(isKeyboardEvent(event)).toEqual(true);
+  });
+
+
+  test(`should return false when not a keyboard event`, function() {
+    const event = createMouseEvent('mouseup');
+    expect(isKeyboardEvent(event)).toEqual(false);
+  });
+
+});

--- a/ngx-tools/type-guards/src/is-keyboard-event/is-keyboard-event.ts
+++ b/ngx-tools/type-guards/src/is-keyboard-event/is-keyboard-event.ts
@@ -1,0 +1,17 @@
+import { isSet } from './../is-set/is-set';
+
+
+/**
+ * Coerce the type to KeyboardEvent
+ *
+ * @param x - The item to test
+ * @return True if the value is a KeyboardEvent
+ *
+ * @example
+ * isKeyboardEvent(myKeyboardEvent); // Returns: true
+ * isKeyboardEvent(myClickEvent);    // Returns: false
+ */
+// tslint:disable-next-line no-any
+export function isKeyboardEvent(x: any): x is KeyboardEvent {
+  return !!x && isSet(x.code);
+}

--- a/ngx-tools/type-guards/src/is-mouse-event/is-mouse-event.spec.ts
+++ b/ngx-tools/type-guards/src/is-mouse-event/is-mouse-event.spec.ts
@@ -1,0 +1,36 @@
+import { KEYS } from '@terminus/ngx-tools/keycodes';
+import {
+  createKeyboardEvent,
+  createMouseEvent,
+} from '@terminus/ngx-tools/testing';
+
+import { isMouseEvent } from './is-mouse-event';
+
+
+describe(`isMouseEvent`, function() {
+
+  test(`should return true for mouse events`, function() {
+    const fakeMouseEvent = createMouseEvent('click');
+    expect(isMouseEvent(fakeMouseEvent)).toEqual(true);
+  });
+
+
+  test(`should return false for anything that is not a mouse event`, function() {
+    const keyboardEvent = createKeyboardEvent('keyup', KEYS.ENTER);
+    const badValues = [
+      keyboardEvent,
+      null,
+      void 0,
+      1,
+      0,
+      'foo',
+      {},
+      '',
+    ];
+
+    for (const value of badValues) {
+      expect(isMouseEvent(value as any)).toEqual(false);
+    }
+  });
+
+});

--- a/ngx-tools/type-guards/src/is-mouse-event/is-mouse-event.ts
+++ b/ngx-tools/type-guards/src/is-mouse-event/is-mouse-event.ts
@@ -1,0 +1,17 @@
+import { isSet } from './../is-set/is-set';
+
+
+/**
+ * Coerce the type to MouseEvent
+ *
+ * @param x - The item to test
+ * @return True if the value is a MouseEvent
+ *
+ * @example
+ * isMouseEvent(myMouseEvent);    // Returns: true
+ * isMouseEvent(myKeyboardEvent); // Returns: false
+ */
+// tslint:disable-next-line no-any
+export function isMouseEvent(x: any): x is MouseEvent {
+  return !!x && isSet(x.relatedTarget);
+}

--- a/ngx-tools/type-guards/src/is-object/is-object.ts
+++ b/ngx-tools/type-guards/src/is-object/is-object.ts
@@ -5,8 +5,8 @@
  * @return The result
  *
  * @example
- * isObject({}); // Returns true
- * isObject('foo'); // Returns false
+ * isObject({});    // Returns: true
+ * isObject('foo'); // Returns: false
  */
 // tslint:disable-next-line no-any
 export function isObject(x: any): x is object {

--- a/tools/cz-config.js
+++ b/tools/cz-config.js
@@ -52,7 +52,7 @@ module.exports = {
     {name: 'Keycodes'},
     {name: 'Regex'},
     {name: 'Testing'},
-    {name: 'Type Guards'},
+    {name: 'TypeGuards'},
     {name: 'Utility'},
 
     {name: 'Build'},


### PR DESCRIPTION
- Add type guards for:
  - `isDragEvent`
  - `isHTMLInputElement`
  - `isKeyboardEvent`
  - `isMouseEvent`
- Update missing JSDoc examples
- Fix mistake in commit type (remove space)