### PR TITLE
fix(Browser): refactor to support better typings

### DIFF
--- a/ngx-tools/browser/testing/src/document.service.mock.ts
+++ b/ngx-tools/browser/testing/src/document.service.mock.ts
@@ -2,15 +2,17 @@ import { Injectable } from '@angular/core';
 import { noop } from '@terminus/ngx-tools/utilities';
 
 
+const document: unknown = {
+  body: {
+    createTextRange: noop,
+    appendChild: noop,
+  },
+  createElement: noop,
+  createRange: () => ({selectNodeContents: noop}),
+  execCommand: noop,
+};
+
 @Injectable()
 export class TsDocumentServiceMock {
-  public document = {
-    body: {
-      createTextRange: noop,
-      appendChild: noop,
-    },
-    createRange: () => ({selectNodeContents: noop}),
-    execCommand: noop,
-    createElement: noop,
-  };
+  public document = document as Document;
 }


### PR DESCRIPTION
After the last release there was an issue where `TsDocumentServiceMock` wasn't allowed to be used in place of `TsDocumentService` due to differences in typings. This change circumvents that issue.
